### PR TITLE
Make httpClient configurable and support request options functions

### DIFF
--- a/dicomweb/dicomweb.go
+++ b/dicomweb/dicomweb.go
@@ -41,6 +41,8 @@ type ClientOption struct {
 	WADOEndpoint string
 	// STOWEndpoint endpoint for STOW.
 	STOWEndpoint string
+	// HTTPClient to perform requests. Uses http.DefaultClient otherwise
+	HTTPClient *http.Client
 }
 
 // WithAuthentication configures the client.
@@ -63,8 +65,12 @@ func (c *Client) WithInsecure() *Client {
 
 // NewClient creates a new client.
 func NewClient(option ClientOption) *Client {
+	httpClient := http.DefaultClient
+	if option.HTTPClient != nil {
+		httpClient = option.HTTPClient
+	}
 	return &Client{
-		httpClient:   &http.Client{},
+		httpClient:   httpClient,
 		qidoEndpoint: option.QIDOEndpoint,
 		wadoEndpoint: option.WADOEndpoint,
 		stowEndpoint: option.STOWEndpoint,

--- a/dicomweb/dicomweb_test.go
+++ b/dicomweb/dicomweb_test.go
@@ -39,6 +39,31 @@ func TestClientWithInsecure(t *testing.T) {
 	assert.Equal(t, true, insecure)
 }
 
+func TestClientWithOptionFunc(t *testing.T) {
+	bearer := "Bearer f2c45335-6bb1-4caf-99d1-7e0849bcad0d"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, bearer, r.Header.Get("Authorization"))
+	}))
+	c := NewClient(ClientOption{
+		QIDOEndpoint: ts.URL,
+		WADOEndpoint: ts.URL,
+		STOWEndpoint: ts.URL,
+		OptionFuncs: &[]OptionFunc{
+			func(req *http.Request) error {
+				req.Header.Set("Authorization", bearer)
+				return nil
+			},
+		},
+	})
+
+	// just make an arbitrary request to mock server.
+	qido := QIDORequest{
+		Type:             Study,
+		StudyInstanceUID: "study-instance-id",
+	}
+	c.Query(qido)
+}
+
 func TestQIDOQueryAllStudy(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/studies", r.URL.String())

--- a/dicomweb/dicomweb_test.go
+++ b/dicomweb/dicomweb_test.go
@@ -208,6 +208,12 @@ part: 1
 	}))
 	c := NewClient(ClientOption{
 		WADOEndpoint: ts.URL,
+		OptionFuncs: &[]OptionFunc{
+			func(req *http.Request) error {
+				// Noop
+				return nil
+			},
+		},
 	}).WithAuthentication("user:name")
 
 	studyInstanceUID := "study-id"
@@ -696,6 +702,12 @@ func TestSTOWStore(t *testing.T) {
 
 	c := NewClient(ClientOption{
 		STOWEndpoint: ts.URL,
+		OptionFuncs: &[]OptionFunc{
+			func(req *http.Request) error {
+				// Noop
+				return nil
+			},
+		},
 	})
 
 	parts := [][]byte{}

--- a/dicomweb/dicomweb_test.go
+++ b/dicomweb/dicomweb_test.go
@@ -81,6 +81,7 @@ func TestClientWithFailingOptionFuncs(t *testing.T) {
 		WADOEndpoint: ts.URL,
 		STOWEndpoint: ts.URL,
 		OptionFuncs: &[]OptionFunc{
+			nil,
 			func(req *http.Request) error {
 				return simulated
 			},


### PR DESCRIPTION
- Make http.Client configurable
- Optionally add functions which modify the requests e.g. for custom authorization methods